### PR TITLE
Allow to print pdf inline with pre-filled filename

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -105,6 +105,16 @@ class Document
 
 
 	/**
+	 * Print a PDF file to screen and sets filename
+	 */
+	public function printPdfInline($filename)
+	{
+		$this->finalize();
+		return $this->mpdf->Output($filename, 'I');
+	}
+
+
+	/**
 	 * Returns instance of mPDF.
 	 *
 	 * @return mPDF


### PR DESCRIPTION
nette-pdf allows inline printing only with no filename provided. This PR adds method for inline printing with pre-filled filename.